### PR TITLE
Check full partition name for creation

### DIFF
--- a/localstorage.js
+++ b/localstorage.js
@@ -3,7 +3,7 @@ function localStorage(dbname){
 	this._keys  = [];
 
 	for (var i = 0; i < window.localStorage.length; i++){
-    	if(window.localStorage.key(i).indexOf(dbname) == 0)
+    	if(window.localStorage.key(i).indexOf(dbname + '!') == 0)
     		this._keys.push(window.localStorage.key(i))
     }
     this._keys.sort();


### PR DESCRIPTION
Checks the full partition name/prefix for localstorage key-value pairs. This prevents the following situation that's currently reachable:

<code>db_helloworld!foo</code> already exists in localStorage,

<code>db_hello</code> is created, and

<code>db_hello</code> contains the key <code>db_helloworld!foo</code> because the namespace "db_helloworld" contains the substring "db_hello" and does not check against the full db name, causing the new db to push the existing <code>db_helloworld!foo</code> key to <code>_keys</code>.
