### PR TITLE
Additional buffer check in put

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ ld.prototype._put = function (key, value, options, callback) {
 
   if (err) return callback(err)
 
-  if(typeof value == 'object' && value.buffer == undefined){
+  if(typeof value == 'object' && !Buffer.isBuffer(value) && value.buffer == undefined){
         var obj = {};
         obj.storetype = "json";
         obj.data = value; 


### PR DESCRIPTION
Backstory: putting attachments with PouchDB using localstorage-down works in Chrome but not Firefox (https://github.com/pouchdb/pouchdb/issues/2098).

Tracked the difference down to this if-guard, which succeeds in Firefox since <code>value.buffer == undefined</code> but not in Chrome. An additional <code>Buffer.isBuffer(value)</code> check seems to take care of the problem, but couldn't be substituted in for the old check or else 2 beefy tests fail. 

It seems like there should be a better solution with one check rather than both of these, but I'm not too familiar with Buffer/ArrayBuffer semantics. In any case, this appears to satisfy both requirements -- open to suggestions.
