### PR TITLE
(#27) - test against full abstract-leveldown suite

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -21,11 +21,8 @@ require('abstract-leveldown/abstract/chained-batch-test').all(localstorage, tape
 require('abstract-leveldown/abstract/approximate-size-test').setUp(localstorage, tape, testCommon);
 require('abstract-leveldown/abstract/approximate-size-test').args(localstorage, tape, testCommon);
 
-//
-// TODO: uncomment these when they're passing
-//
-//require('abstract-leveldown/abstract/ranges-test').all(localstorage, tape, testCommon)
-//require('abstract-leveldown/abstract/batch-test').all(localstorage, tape, testCommon)
+require('abstract-leveldown/abstract/ranges-test').all(localstorage, tape, testCommon);
+require('abstract-leveldown/abstract/batch-test').all(localstorage, tape, testCommon);
 
 require('./custom-tests.js').all(localstorage, tape, testCommon);
 


### PR DESCRIPTION
Also fix the iterator logic for new API additions
like gt, gte, lt, lte, and exclusiveStart. Much of
the code is copied wholesale from MemDOWN, since they
did it correctly over there.
