### PR TITLE
(#37) - fix Uint8Array parse issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ LD.prototype._get = function (key, options, callback) {
 
 
   if (options.asBuffer !== false && !Buffer.isBuffer(value)) {
-    value = new Buffer(String(value));
+    value = new Buffer(value);
   }
 
 

--- a/localstorage.js
+++ b/localstorage.js
@@ -71,7 +71,7 @@ LocalStorage.prototype.getItem = function (key) {
     return retval;
   } else if (uintRegex.test(retval)) {
     value = retval.substring(uintPrefix.length);
-    retval = new Uint8Array(atob(value).split('').map(function(c) {
+    retval = new Uint8Array(atob(value).split('').map(function (c) {
       return c.charCodeAt(0);
     }));
     return retval;

--- a/tests/test.js
+++ b/tests/test.js
@@ -3,9 +3,9 @@
 var tape   = require('tape');
 var localstorage = require('../');
 var testCommon = require('./testCommon');
-var testBuffer = new Uint8Array('hello'.split('').map(function (c) {
+var testBuffer = new Buffer(new Uint8Array('hello'.split('').map(function (c) {
   return c.charCodeAt(0);
-}));
+})));
 
 require('abstract-leveldown/abstract/leveldown-test').args(localstorage, tape);
 require('abstract-leveldown/abstract/open-test').args(localstorage, tape, testCommon);


### PR DESCRIPTION
Our own unit tests were incorrect, which is
probably what was misleading us about how
to properly pull Uint8Arrays out of the
database.  The tests now pass both here
and in PouchDB.
