### PR TITLE
(#39) - catch exceptions, abstractify

### DIFF
--- a/localstorage-core.js
+++ b/localstorage-core.js
@@ -1,0 +1,85 @@
+'use strict';
+
+//
+// Class that should contain everything necessary to interact
+// with localStorage as a generic key-value store.
+// The idea is that authors who want to create an AbstractKeyValueDOWN
+// module (e.g. on lawnchair, S3, whatever) will only have to
+// reimplement this file.
+//
+
+// see http://stackoverflow.com/a/15349865/680742
+var nextTick = global.setImmediate || process.nextTick;
+
+function callbackify(callback, fun) {
+  var val;
+  var err;
+  try {
+    val = fun();
+  } catch (e) {
+    err = e;
+  }
+  nextTick(function () {
+    callback(err, val);
+  });
+}
+
+function createPrefix(dbname) {
+  return dbname.replace(/!/g, '!!') + '!'; // escape bangs in dbname;
+}
+
+function LocalStorageCore(dbname) {
+  this._prefix = createPrefix(dbname);
+}
+
+LocalStorageCore.prototype.getKeys = function (callback) {
+  var self = this;
+  callbackify(callback, function () {
+    var keys = [];
+    var prefixLen = self._prefix.length;
+    var i = -1;
+    var len = window.localStorage.length;
+    while (++i < len) {
+      var fullKey = window.localStorage.key(i);
+      if (fullKey.substring(0, prefixLen) === self._prefix) {
+        keys.push(fullKey.substring(prefixLen));
+      }
+    }
+    keys.sort();
+    return keys;
+  });
+};
+
+LocalStorageCore.prototype.put = function (key, value, callback) {
+  var self = this;
+  callbackify(callback, function () {
+    window.localStorage.setItem(self._prefix + key, value);
+  });
+};
+
+LocalStorageCore.prototype.get = function (key, callback) {
+  var self = this;
+  callbackify(callback, function () {
+    return window.localStorage.getItem(self._prefix + key);
+  });
+};
+
+LocalStorageCore.prototype.remove = function (key, callback) {
+  var self = this;
+  callbackify(callback, function () {
+    window.localStorage.removeItem(self._prefix + key);
+  });
+};
+
+LocalStorageCore.destroy = function (dbname, callback) {
+  var prefix = createPrefix(dbname);
+  callbackify(callback, function () {
+    Object.keys(localStorage).forEach(function (key) {
+      if (key.substring(0, prefix.length) === prefix) {
+        localStorage.removeItem(key);
+      }
+    });
+  });
+};
+
+module.exports = LocalStorageCore;

--- a/localstorage.js
+++ b/localstorage.js
@@ -6,86 +6,125 @@ var uintPrefix = 'Uint8Array:';
 var uintRegex = new RegExp('^' + uintPrefix);
 
 var utils = require('./utils');
+var LocalStorageCore = require('./localstorage-core');
+var TaskQueue = require('./taskqueue');
 
 function LocalStorage(dbname) {
-  this._keys = [];
-  this._prefix = dbname.replace(/!/g, '!!') + '!'; // escape bangs in dbname
-
-  var prefixLen = this._prefix.length;
-  var i = -1;
-  var len = window.localStorage.length;
-  while (++i < len) {
-    var fullKey = window.localStorage.key(i);
-    if (fullKey.substring(0, prefixLen) === this._prefix) {
-      this._keys.push(fullKey.substring(prefixLen));
-    }
-  }
-  this._keys.sort();
+  this._store = new LocalStorageCore(dbname);
+  this._queue = new TaskQueue();
 }
 
-//key: Returns the name of the key at the position specified.
-LocalStorage.prototype.key = function (keyindex) {
-  return this._keys[keyindex];
+LocalStorage.prototype.sequentialize = function (callback, fun) {
+  this._queue.add(fun, callback);
+};
+
+LocalStorage.prototype.init = function (callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    self._store.getKeys(function (err, keys) {
+      if (err) {
+        return callback(err);
+      }
+      self._keys = keys;
+      return callback();
+    });
+  });
 };
 
 // returns the key index if found, else the index where
-// the key should be inserted
-LocalStorage.prototype.indexOfKey = function(key) {
-  return utils.sortedIndexOf(this._keys, key);
+// the key should be inserted. also returns the key
+// at that index
+LocalStorage.prototype.binarySearch = function (key, callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    var index = utils.sortedIndexOf(self._keys, key);
+    var foundKey = (index >= self._keys.length || index < 0) ?
+        undefined : self._keys[index];
+    callback(null, {index: index, key: foundKey});
+  });
+};
+
+LocalStorage.prototype.getKeyAt = function (index, callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    var foundKey = (index >= self._keys.length || index < 0) ?
+      undefined : self._keys[index];
+    callback(null, foundKey);
+  });
 };
 
 //setItem: Saves and item at the key provided.
-LocalStorage.prototype.setItem = function (key, value) {
-  if (value instanceof ArrayBuffer) {
-    value = arrayBuffPrefix + btoa(String.fromCharCode.apply(null, value));
-  } else if (value instanceof Uint8Array) {
-    value = uintPrefix + btoa(String.fromCharCode.apply(null, value));
-  }
+LocalStorage.prototype.setItem = function (key, value, callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    if (value instanceof ArrayBuffer) {
+      value = arrayBuffPrefix + btoa(String.fromCharCode.apply(null, value));
+    } else if (value instanceof Uint8Array) {
+      value = uintPrefix + btoa(String.fromCharCode.apply(null, value));
+    }
 
-  var idx = utils.sortedIndexOf(this._keys, key);
-  if (this._keys[idx] !== key) {
-    this._keys.splice(idx, 0, key);
-  }
-  window.localStorage.setItem(this._prefix + key, value);
+    var idx = utils.sortedIndexOf(self._keys, key);
+    if (self._keys[idx] !== key) {
+      self._keys.splice(idx, 0, key);
+    }
+    self._store.put(key, value, callback);
+  });
 };
 
 //getItem: Returns the item identified by it's key.
-LocalStorage.prototype.getItem = function (key) {
-  var value;
-
-  var retval = window.localStorage.getItem(this._prefix + key);
-  if (retval == null) {
-    return undefined;
-  }
-
-  if (arrayBuffRegex.test(retval)) {
-    value = retval.substring(arrayBuffPrefix.length);
-    retval = new ArrayBuffer(atob(value).split('').map(function (c) {
-      return c.charCodeAt(0);
-    }));
-    return retval;
-  } else if (uintRegex.test(retval)) {
-    value = retval.substring(uintPrefix.length);
-    retval = new Uint8Array(atob(value).split('').map(function (c) {
-      return c.charCodeAt(0);
-    }));
-    return retval;
-  }
-  return retval;
+LocalStorage.prototype.getItem = function (key, callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    self._store.get(key, function (err, retval) {
+      if (err) {
+        return callback(err);
+      }
+      if (typeof retval === 'undefined' || retval === null) {
+        // 'NotFound' error, consistent with LevelDOWN API
+        return callback(new Error('NotFound'));
+      }
+      if (typeof retval !== 'undefined') {
+        if (arrayBuffRegex.test(retval)) {
+          retval = retval.substring(arrayBuffPrefix.length);
+          retval = new ArrayBuffer(atob(retval).split('').map(function (c) {
+            return c.charCodeAt(0);
+          }));
+        } else if (uintRegex.test(retval)) {
+          retval = retval.substring(uintPrefix.length);
+          retval = new Uint8Array(atob(retval).split('').map(function (c) {
+            return c.charCodeAt(0);
+          }));
+        }
+      }
+      callback(null, retval);
+    });
+  });
 };
 
 //removeItem: Removes the item identified by it's key.
-LocalStorage.prototype.removeItem = function (key) {
-
-  var idx = utils.sortedIndexOf(this._keys, key);
-  if (this._keys[idx] === key) {
-    this._keys.splice(idx, 1);
-    window.localStorage.removeItem(this._prefix + key);
-  }
+LocalStorage.prototype.removeItem = function (key, callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    var idx = utils.sortedIndexOf(self._keys, key);
+    if (self._keys[idx] === key) {
+      self._keys.splice(idx, 1);
+      self._store.remove(key, function (err) {
+        if (err) {
+          return callback(err);
+        }
+        callback();
+      });
+    } else {
+      callback();
+    }
+  });
 };
 
-LocalStorage.prototype.length = function () {
-  return this._keys.length;
+LocalStorage.prototype.length = function (callback) {
+  var self = this;
+  self.sequentialize(callback, function (callback) {
+    callback(null, self._keys.length);
+  });
 };
 
 exports.LocalStorage = LocalStorage;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "version": "0.5.2",
   "main": "index.js",
   "dependencies": {
-    "abstract-leveldown": "~0.12.0"
+    "abstract-leveldown": "~0.12.0",
+    "argsarray": "0.0.1",
+    "inherits": "^2.0.1",
+    "tiny-queue": "0.2.0"
   },
   "devDependencies": {
     "beefy": "~1.1.0",

--- a/taskqueue.js
+++ b/taskqueue.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var argsarray = require('argsarray');
+var Queue = require('tiny-queue');
+
+// see http://stackoverflow.com/a/15349865/680742
+var nextTick = global.setImmediate || process.nextTick;
+
+function TaskQueue() {
+  this.queue = new Queue();
+  this.running = false;
+}
+
+TaskQueue.prototype.add = function (fun, callback) {
+  this.queue.push({fun: fun, callback: callback});
+  this.processNext();
+};
+
+TaskQueue.prototype.processNext = function () {
+  var self = this;
+  if (self.running || !self.queue.length) {
+    return;
+  }
+  self.running = true;
+
+  var task = self.queue.shift();
+  nextTick(function () {
+    task.fun(argsarray(function (args) {
+      task.callback.apply(null, args);
+      self.running = false;
+      self.processNext();
+    }));
+  });
+};
+
+module.exports = TaskQueue;


### PR DESCRIPTION
So this is a big commit, but it represents
the direction I would like localstorage-down
to go in: more modular, more easily
separable into an abstract-keyvalue-down
component and a core localstorage component.

Notice that everything that touches localStorage
itself has been moved into localstorage-core. Also,
all access has been made sequential and asynchronous,
so in principle localstorage-core could be subbed
out for any key-value storage system.  (My sights
are currently set on lawnchair and Amazon S3.)

As for this commit itself, if you want to test in
PouchDB, you'll have to wait on pouchdb/pouchdb#2252.
But I tested it, and it passes at 100%.
