### PR TITLE
peg abstract-leveldown to 0.12.3 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "version": "0.6.0",
   "main": "index.js",
   "dependencies": {
-    "abstract-leveldown": "~0.12.0",
+    "abstract-leveldown": "0.12.3",
     "argsarray": "0.0.1",
     "inherits": "^2.0.1",
     "tiny-queue": "0.2.0"


### PR DESCRIPTION
We need to peg abstract-leveldown to a version from two months ago, because we don't currently pass the "iterator snapshot" test. Didn't even realize iterators were supposed to make snapshots.
