### PR TITLE
(#61) - fix concurrent batch del while iterating 

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,15 +88,16 @@ LDIterator.prototype._next = function (callback) {
         return callback();
       }
 
-      self._pos += self._reverse ? -1 : 1;
-
       self.db.container.getItem(key, function (err, value) {
         if (err) {
           if (err.message === 'NotFound') {
-            return callback();
+            return nextTick(function () {
+              self._next(callback);
+            });
           }
           return callback(err);
         }
+        self._pos += self._reverse ? -1 : 1;
         callback(null, key, value);
       });
     });


### PR DESCRIPTION
Based on the localStorage-only failures in https://github.com/pouchdb/pouchdb/pull/2846, I've been trying to figure out if there's a race condition in localstorage-down.

I noticed @calvinmetcalf's fix in memdown (https://github.com/rvagg/memdown/commit/8a3c6a02954f6dcfc7e74b209a897654cdbb282c), but after copying the test and the fix over, it doesn't seem to have an impact here. The test was already passing before. Added another test, but same story - it was already passing.
