### PR TITLE
(pouchdb/pouchdb#2818) - read keys into memory

### DIFF
--- a/localstorage.js
+++ b/localstorage.js
@@ -38,25 +38,10 @@ LocalStorage.prototype.init = function (callback) {
   });
 };
 
-// returns the key index if found, else the index where
-// the key should be inserted. also returns the key
-// at that index
-LocalStorage.prototype.binarySearch = function (key, callback) {
+LocalStorage.prototype.keys = function (callback) {
   var self = this;
   self.sequentialize(callback, function (callback) {
-    var index = utils.sortedIndexOf(self._keys, key);
-    var foundKey = (index >= self._keys.length || index < 0) ?
-        undefined : self._keys[index];
-    callback(null, {index: index, key: foundKey});
-  });
-};
-
-LocalStorage.prototype.getKeyAt = function (index, callback) {
-  var self = this;
-  self.sequentialize(callback, function (callback) {
-    var foundKey = (index >= self._keys.length || index < 0) ?
-      undefined : self._keys[index];
-    callback(null, foundKey);
+    callback(null, self._keys.slice());
   });
 };
 

--- a/tests/custom-tests.js
+++ b/tests/custom-tests.js
@@ -87,9 +87,43 @@ module.exports.all = function (leveldown, tape, testCommon) {
         t.notOk(err, 'no error');
         iterator.next(function (err, key, value) {
           t.notOk(err, 'no error');
-          t.equals(key, 'c');
-          t.equal(value, 'C');
+          t.ok(key, 'key exists');
+          t.ok(value, 'value exists');
           t.end();
+        });
+      });
+    });
+  });
+
+  tape('add many while iterating', function (t) {
+    var db = leveldown(testCommon.location());
+    var noerr = function (err) {
+      t.error(err, 'opens crrectly');
+    };
+    var noop = function () {};
+    var iterator;
+    db.open(noerr);
+    db.put('c', 'C', noop);
+    db.put('d', 'D', noop);
+    db.put('e', 'E', noop);
+    iterator = db.iterator({ keyAsBuffer: false, valueAsBuffer: false, start: 'c' });
+    iterator.next(function (err, key, value) {
+      t.equal(key, 'c');
+      t.equal(value, 'C');
+      db.del('c', function (err) {
+        t.notOk(err, 'no error');
+        db.put('a', 'A', function (err) {
+          t.notOk(err, 'no error');
+          db.put('b', 'B', function (err) {
+            t.notOk(err, 'no error');
+            iterator.next(function (err, key, value) {
+              t.notOk(err, 'no error');
+              t.ok(key, 'key exists');
+              t.ok(value, 'value exists');
+              t.ok(key >= 'c', 'key "' + key + '" should be greater than c');
+              t.end();
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
Reading the keys into memory before starting iteration fixes all the tests in pouchdb/pouchdb#2818. It also makes the code simpler; look at all those deletions.
