### PR TITLE
(#60) - test in saucelabs and node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: node_js
+
+node_js:
+  - stable
+
+git:
+  depth: 10
+
+addons:
+  sauce_connect: true
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+
+script: npm run $COMMAND
+
+env:
+  global:
+    - secure: "G1qQhww+f9uQmmXGEyUEEip/wged9mkkAtg4IoywuGP9wo0mSkSiIOJ8i1o9H2RCV2YNBBwt0RbaI6g1N5QvhWt9hbm99rQZCgAW2loTLPDtod4FaM07gc7SlrlLwKkSe1v6+b3fO4BmwLk7C1dYMLek1aGaWNEEGXjUpuNuw3JN4+BzNtLbWEnKqUS9bhEdrmoRXk+nuQiR26Tg02ZcuGTMAVSAWvvzBdZacN8Tu/Tveq6MUay/P6CBE8ovoHUAyXio++0mbWZubq9zC6DvSMAMCe0tbUGKar1dtH7jWQnC1gW40SUcDunBkdjFts297JbdeXj+IEv/Sd869Un3c6zjmFY4w65LCAb9QDYVOxZU+1lVvTRyR5oQ7rA6mS815YcgNGdqSZMdhZxGvmJyiSaSHSG7emWkz75Xt5ZHE6H7J79JAaxT3DHLWeTVwr1excJum3H5i2SPCv3nBPI+o6zSif+6oqU+VbPoFIoFhAkjtrP2qPB0WFteDUaX1NpBRe0MgaZeiwcQPxMx4+L1TOotO93Ecyy0Ch2ALc60sYK3fjEFEnsN/6aS4K5Awcoi05VYnif3aTaFHOvuyt5sfydeM8KyQEqvnbowSsHpsb0oWU3cmVpooxeuO85mQFgeZJnSt2YpncDSC348tBja5J1DM24wA7RT7lXtbGW4B2E="
+    - secure: "NNcrDHNrO34CMJLOqDhs35rtj1ddOsBPQ+gN9VZZQnU+9v3CjOKB6MXNmNLDpupz3MTTwYa4dGOA37cjqKA1lE9v4pGaAyi6Xm8QWR8ZxFrFXli5oPfqLK/sLEsdHMvoenEucckZ0NshkTqatK+lrl/n8y06fWCvl+diIMxlvaWDb7tVVYZW97OmPCic8XoHU9VNAdOOshu6jjJQVKgGJ3ldX02/VcVtIT5ld0p2ipnPn5RTQzFu4YsGPR+tX4lJr9mDHyS8OtYabuPnad2npymUKddnGZmSEFe/3J1SxGeJWmNr4iJerC8bWWxw6NFNOvXElfqQOU0R99NbfMVpw+O2WnJg3pM9JR2QDn/gGXZHAEHYc9o4FJluJnxEpYY7hLqs/2fPkAFTDWflkMMnAJnWX/lO42/YO/rC1Z87OT0eWgQ+i6N/W8rHJyQGqRKS5JTf8s3MJGM2835DItyKihEeLxpqibtRj5EszhN0vWqKBRCf2L5JX58yp8JUQcm5sAjElfuNaWKClf4oK3FqmzhDGSojK2Tnv3eZkLwqEqAwwzDwGUMiqre00YGXT+Rn135b8Wp2az5yb1HcPNmS97UuKH6y+Ok4CL13pw+W6KuhCRcxY0VqVUMXw7cWjE4GGNYXwbStZnpnb3AYerf9rzBWidHd22uVhGCfBQIwIpY="
+
+  matrix:
+    - COMMAND=test
+    - COMMAND=test-saucelabs BROWSER_NAME=iphone BROWSER_VERSION="8.0..latest"
+    - COMMAND=test-saucelabs BROWSER_NAME=safari BROWSER_VERSION="7..latest"
+    - COMMAND=test-saucelabs BROWSER_NAME=android BROWSER_VERSION="4..latest"
+    - COMMAND=test-saucelabs BROWSER_NAME=ie BROWSER_VERSION="8..latest"
+    - COMMAND=test-saucelabs BROWSER_NAME=firefox BROWSER_VERSION="38..latest"
+    - COMMAND=test-saucelabs BROWSER_NAME=chrome BROWSER_VERSION="42..beta"
+

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ The scenarios envisaged are :
 
 This project is intended for use with the [level eco-system](https://github.com/level/).
 
-## Status 
-
-[![browser support](https://ci.testling.com/no9/localstorage-down.png)](https://ci.testling.com/no9/localstorage-down)
-
 ## Install
 
 ```
@@ -28,6 +24,18 @@ Basically we support [any browser that has localStorage](http://caniuse.com/name
 
 * [typedarray](https://github.com/substack/typedarray) for binary storage
 * [es5-shim](https://github.com/es-shims/es5-shim) for just about everything
+
+We run automated tests in the following browsers:
+
+* **Android**: 4.0-5.1
+* **Firefox**: 38-42
+* **Chrome**: 42-beta
+* **IE**: 8-11
+* **iPhone**: 8.0-9.1
+* **Safari**: 7.1-9
+
+In environments without LocalStorage, such as Node or Safari private browsing, this module
+will fall back to a temporary in-memory implementation, thanks to [humble-localstorage](https://www.npmjs.com/package/humble-localstorage).
 
 ## Example 
 
@@ -89,8 +97,19 @@ http://www.youtube.com/watch?v=ExUosomc8Uc
 npm run test
 ```
 
-Browse to [http://localhost:9966](http://localhost:9966). 
-View console logs in the browser to see test output. 
+This will run tests in Node against `localstorage-memory`. 
+
+To test in Saucelabs, you can run e.g.:
+
+```
+BROWSER_NAME=firefox BROWSER_VERSION="38..latest" npm run test-saucelabs
+```
+
+Or to test in Zuul locally:
+
+```
+npm run test-zuul-local
+```
 
 ##  Contributors
 

--- a/localstorage-core.js
+++ b/localstorage-core.js
@@ -11,6 +11,11 @@
 // see http://stackoverflow.com/a/15349865/680742
 var nextTick = global.setImmediate || process.nextTick;
 
+// We use humble-localstorage as a wrapper for localStorage because
+// it falls back to an in-memory implementation in environments without
+// localStorage, like Node or Safari private browsing.
+var storage = require('humble-localstorage');
+
 function callbackify(callback, fun) {
   var val;
   var err;
@@ -38,9 +43,9 @@ LocalStorageCore.prototype.getKeys = function (callback) {
     var keys = [];
     var prefixLen = self._prefix.length;
     var i = -1;
-    var len = window.localStorage.length;
+    var len = storage.length;
     while (++i < len) {
-      var fullKey = window.localStorage.key(i);
+      var fullKey = storage.key(i);
       if (fullKey.substring(0, prefixLen) === self._prefix) {
         keys.push(fullKey.substring(prefixLen));
       }
@@ -53,32 +58,35 @@ LocalStorageCore.prototype.getKeys = function (callback) {
 LocalStorageCore.prototype.put = function (key, value, callback) {
   var self = this;
   callbackify(callback, function () {
-    window.localStorage.setItem(self._prefix + key, value);
+    storage.setItem(self._prefix + key, value);
   });
 };
 
 LocalStorageCore.prototype.get = function (key, callback) {
   var self = this;
   callbackify(callback, function () {
-    return window.localStorage.getItem(self._prefix + key);
+    return storage.getItem(self._prefix + key);
   });
 };
 
 LocalStorageCore.prototype.remove = function (key, callback) {
   var self = this;
   callbackify(callback, function () {
-    window.localStorage.removeItem(self._prefix + key);
+    storage.removeItem(self._prefix + key);
   });
 };
 
 LocalStorageCore.destroy = function (dbname, callback) {
   var prefix = createPrefix(dbname);
   callbackify(callback, function () {
-    Object.keys(localStorage).forEach(function (key) {
-      if (key.substring(0, prefix.length) === prefix) {
-        localStorage.removeItem(key);
+    var len = storage.length;
+    var i = -1;
+    while (++i < len) {
+      var key = storage.key(i);
+      if (key && key.substring(0, prefix.length) === prefix) {
+        storage.removeItem(key);
       }
-    });
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "abstract-leveldown": "0.12.3",
     "argsarray": "0.0.1",
     "d64": "^1.0.0",
+    "humble-localstorage": "^1.4.2",
     "inherits": "^2.0.1",
     "tiny-queue": "0.2.0"
   },
   "devDependencies": {
-    "beefy": "~1.1.0",
     "browserify": "^4.1.2",
+    "jshint": "^2.5.0",
     "levelup": "^0.18.2",
     "tape": "^2.12.3",
-    "jshint": "^2.5.0"
+    "zuul": "^3.7.3"
   },
   "repository": {
     "type": "git",
@@ -36,7 +37,9 @@
     "bindings": false
   },
   "scripts": {
-    "test": "npm run jshint && beefy tests/test.js",
+    "test": "npm run jshint && tape tests/*.js",
+    "test-saucelabs": "npm run jshint && zuul --ui tape --browser-name $BROWSER_NAME --browser-version $BROWSER_VERSION -- tests/*.js",
+    "test-zuul-local": "npm run jshint && zuul --ui tape --local tests/*.js",
     "jshint": "jshint -c .jshintrc *.js tests/*.js"
   },
   "testling": {

--- a/tests/custom-tests.js
+++ b/tests/custom-tests.js
@@ -18,7 +18,7 @@ module.exports.all = function (leveldown, tape, testCommon) {
     var db = levelup('destroy-test', {db: leveldown});
     var db2 = levelup('other-db', {db: leveldown});
     db2.put('key2', 'value2', function (err) {
-      t.notOk(err, 'no error');
+      t.notOk(err, 'no error' );
       db.put('key', 'value', function (err) {
         t.notOk(err, 'no error');
         db.get('key', function (err, value) {

--- a/tests/testCommon.js
+++ b/tests/testCommon.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var storage = require('humble-localstorage');
+
 var dbidx = 0;
 var theLocation = function () {
   return '_leveldown_test_db_' + dbidx++;
@@ -10,10 +12,7 @@ var lastLocation = function () {
 };
 
 var cleanup = function (callback) {
-
-  if (window.localStorage) {
-    window.localStorage.clear();
-  }
+  storage.clear();
 
   return callback();
 };


### PR DESCRIPTION
Swaps out Zuul for Beefy, so that we can test
in Saucelabs. Also adds Node tests, which actually
work because we are now using humble-localstorage
as a wrapper (1KB min+gz) for window.localStorage,
with the added benefit this this module will now
work in Safari private browsing (using an in-memory
fallback).