### PR TITLE
update levelup/abstract-leveldown to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "version": "0.6.6",
   "main": "lib/index.js",
   "dependencies": {
-    "abstract-leveldown": "0.12.3",
+    "abstract-leveldown": "^2.4.1",
     "argsarray": "0.0.1",
     "d64": "^1.0.0",
     "humble-localstorage": "^1.4.2",
@@ -28,7 +28,7 @@
     "istanbul": "^0.4.1",
     "istanbul-coveralls": "^1.0.3",
     "jshint": "^2.5.0",
-    "levelup": "^0.18.2",
+    "levelup": "^1.3.1",
     "tape": "^2.12.3",
     "zuul": "^3.10.1"
   },


### PR DESCRIPTION
I am unsurprised to see that this is failing, but I just
wanted to see how badly it's failing and where exactly
it's broken. This is something we should fix.
