### PR TITLE
(#76) - correctly iterate when destroying

### DIFF
--- a/localstorage-core.js
+++ b/localstorage-core.js
@@ -79,11 +79,10 @@ LocalStorageCore.prototype.remove = function (key, callback) {
 LocalStorageCore.destroy = function (dbname, callback) {
   var prefix = createPrefix(dbname);
   callbackify(callback, function () {
-    var len = storage.length;
-    var i = -1;
-    while (++i < len) {
+    var i = storage.length;
+    while (--i >= 0) {
       var key = storage.key(i);
-      if (key && key.substring(0, prefix.length) === prefix) {
+      if (key.substring(0, prefix.length) === prefix) {
         storage.removeItem(key);
       }
     }

--- a/tests/custom-tests.js
+++ b/tests/custom-tests.js
@@ -44,6 +44,39 @@ module.exports.all = function (leveldown, tape, testCommon) {
     });
   });
 
+  tape('test .destroy with multiple dbs', function (t) {
+    var db = levelup('a', {db: leveldown});
+    var db2 = levelup('b', {db: leveldown});
+    var db3 = levelup('c', {db: leveldown});
+    db.put('1', '1', function (err) {
+      t.notOk(err, 'no error');
+      db2.put('1', '1', function (err) {
+        t.notOk(err, 'no error');
+        db3.put('1', '1', function (err) {
+          t.notOk(err, 'no error');
+          db2.put('2', '2', function (err) {
+            t.notOk(err, 'no error');
+            db2.put('3', '3', function (err) {
+              t.notOk(err, 'no error');
+              leveldown.destroy('b', function (err) {
+                t.notOk(err, 'no error');
+                db3.get('1', function (err, res) {
+                  t.notOk(err, 'no error');
+                  t.equal(res, '1');
+                  db2 = levelup('b', {db: leveldown});
+                  db2.get('3', function (err) {
+                    t.ok(err);
+                    t.end();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   tape('test escaped db name', function (t) {
     var db = levelup('bang!', {db: leveldown});
     var db2 = levelup('bang!!', {db: leveldown});


### PR DESCRIPTION
The previous loop logic was incorrect, because it
was destroying the localStorage array as it iterated. The
proper way to delete elements in an array by index
is to iterate backwards, so you don't destroy the
array while you're looping.

The new test fails before the fix but succeeds after.