### PR TITLE
bypass getItem on keys-only db streams (re-rebased)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ function LDIterator(db, options) {
   this._lt      = options.lt;
   this._lte     = options.lte;
   this._exclusiveStart = options.exclusiveStart;
+  this._keysOnly = options.values === false;
   this._limit = options.limit;
   this._count = 0;
 
@@ -64,6 +65,10 @@ LDIterator.prototype._next = function (callback) {
     }
 
     self._pos += self._reverse ? -1 : 1;
+    if (self._keysOnly) {
+      return callback(null, key);
+    }
+
     self.db.container.getItem(key, function (err, value) {
       if (err) {
         if (err.message === 'NotFound') {


### PR DESCRIPTION
Should pass, now that localstorage-memory is updated. I also fixed the test to ensure the database is closed.
