### PR TITLE
(#76) - fix localstorage destroy()

### DIFF
--- a/localstorage-core.js
+++ b/localstorage-core.js
@@ -79,13 +79,18 @@ LocalStorageCore.prototype.remove = function (key, callback) {
 LocalStorageCore.destroy = function (dbname, callback) {
   var prefix = createPrefix(dbname);
   callbackify(callback, function () {
-    var i = storage.length;
-    while (--i >= 0) {
+    var keysToDelete = [];
+    var i = -1;
+    var len = storage.length;
+    while (++i < len) {
       var key = storage.key(i);
       if (key.substring(0, prefix.length) === prefix) {
-        storage.removeItem(key);
+        keysToDelete.push(key);
       }
     }
+    keysToDelete.forEach(function (key) {
+      storage.removeItem(key);
+    });
   });
 };
 


### PR DESCRIPTION
This fixes the PouchDB test suite. I did not add a new test
to this repo, because I didn't have time.

These tests were broken in Firefox and Safari but not Chrome.
Apparently the issue is that LocalStorage implementations are
allowed to reorder the keys before and after removing items,
meaning we can't count on the order to stay the same while
we're deleting stuff. The W3C spec has more info:
https://www.w3.org/TR/webstorage/