### PR TITLE
Fix Saucelabs/Zuul tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,11 @@ env:
   matrix:
   - COMMAND=test
   - COMMAND=report-coverage
-  - COMMAND=test-saucelabs BROWSER_NAME=iphone BROWSER_VERSION="8.0..latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=safari BROWSER_VERSION="7..latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=android BROWSER_VERSION="4.1..latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=ie BROWSER_VERSION="9..latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=microsoftedge BROWSER_VERSION="latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=firefox BROWSER_VERSION="43..latest"
-  - COMMAND=test-saucelabs BROWSER_NAME=chrome BROWSER_VERSION="47..beta"
+  - COMMAND=test-browser
   global:
   - secure: sg7XninkGV8c95tZgZDu9dDL22TqrDKUdES+I92H+3A9vY9GZVtFpp9l5AKLLrdj7FjJ+fSsMT1XN+zE3Ljj2EpHVJqNAqo0CmNYm+lfeyI6Z50eOeuGCsjaJPiMNpeD32nghG7tIBl4JVG0hcHs+AkFtWGQoj7n+8sJXWNwE9E=
   - secure: iHZwuxZUEYRujfoDt2rZJXq0o/15j0FpJFEoV2pzhq+zUIuqbuS9vUzvE0dpfvYq+MkrIe77O2q8cRilNjw5zRZltmU6HXHKq6qRyS+vbhiXEMzm4ucvQLDHDejSq5Xrfv+yOg0z5JBzSesrP4h6l50ohvRZGtkmGXRFN/zA0Rs=
+  - secure: U2CJxbwO5HV9X7T+WnduZr4ZbcOB8tE/05q+3fi/X0zaSxgOTG7lOmngiNjnFB1lJXRS00iCE8QJ2pplrltGlcAeJLx1/fCOc5jmBbVuf0jt/qT5cKN8i87PO6SSdr7dhjwFzrqOxJ6AzMOO69nw6R7+stQaAvQCXP/Gg0szfWA=
 branches:
   only:
   - master

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,22 @@
+ui: tape
+coverage: false
+concurrency: 2
+tunnel:
+  type: ngrok
+browsers:
+  - name: chrome
+    version: latest
+  - name: firefox
+    version: latest
+  - name: safari
+    version: [8, 9]
+  - name: ie
+    version: 8..latest
+  - name: microsoftedge
+    version: latest
+  - name: iphone
+    version: 8.4
+  - name: ipad
+    version: 8.4
+  - name: android
+    version: [4.4, 5.1]

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -11,7 +11,7 @@ browsers:
   - name: safari
     version: [8, 9]
   - name: ie
-    version: 8..latest
+    version: 9..11
   - name: microsoftedge
     version: latest
   - name: iphone

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This will run tests in Node against `localstorage-memory`.
 
 To test in Saucelabs, you can run e.g.:
 
-    BROWSER_NAME=firefox BROWSER_VERSION="38..latest" npm run test-saucelabs
+    npm run test-browser
 
 Or to test in Zuul locally:
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jshint": "2.8.0",
     "levelup": "^0.18.2",
     "tape": "^2.12.3",
-    "zuul": "^3.10.1"
+    "zuul": "^3.10.1",
+    "zuul-ngrok": "nolanlawson/zuul-ngrok#patch-1"
   },
   "repository": {
     "type": "git",
@@ -41,8 +42,8 @@
   },
   "scripts": {
     "test": "npm run jshint && tape tests/*.js",
-    "test-saucelabs": "npm run jshint && zuul --no-coverage --ui tape --browser-name $BROWSER_NAME --browser-version $BROWSER_VERSION tests/*.js",
-    "test-zuul-local": "npm run jshint && zuul --no-coverage --ui tape --local tests/*.js",
+    "test-browser": "npm run jshint && zuul tests/*.js",
+    "test-zuul-local": "npm run jshint && zuul --local tests/*.js",
     "jshint": "jshint -c .jshintrc lib/*.js tests/*.js",
     "coverage": "istanbul cover ./node_modules/.bin/tape tests/*.js && istanbul check-coverage --lines 50 --function 50 --statements 50 --branches 50",
     "report-coverage": "npm run coverage && istanbul-coveralls --no-rm"


### PR DESCRIPTION
localtunnel isn't reliable anymore in my experience, so I bought a Ngrok account and I'm happy to share it with localstorage-down.

This also changes our Travis tests so that all Saucelabs tests are run in one go rather than in separate tests.